### PR TITLE
Refactor CSS styling to comform to game-frame size restriciton

### DIFF
--- a/team04/index.css
+++ b/team04/index.css
@@ -9,6 +9,15 @@ Owned by Team 04
     padding: 0;
 }
 
+body {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    min-width: 100vw;
+    min-height: 100vh;
+}
+
 button {
     cursor: pointer;
 }
@@ -17,20 +26,17 @@ button {
     align-items: center;
     display: flex;
     flex-direction: column;
-    flex-wrap: wrap;
+    height: 100%;
     justify-content: space-between;
-    min-height: 100vh;
-    min-width: 100vw;
+    width: 100%;
 }
 
-/* Cards + Clock */ 
-.center-section {
-    align-items: center;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 5vw;
-    height: 50vh;
+#app > * {
+    width: 100%;
 }
+
+
+
+
 
 

--- a/team04/index.html
+++ b/team04/index.html
@@ -10,7 +10,7 @@ Owned by Team 04
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Basic Static Site</title>
+  <title>Clock it!</title>
   <link rel="stylesheet" href="../style.css" />
 
   <script src="../scripts/vocabulary.js"></script>
@@ -25,11 +25,11 @@ Owned by Team 04
 
   <!-- Site specific scripts and styles -->
   <link rel="stylesheet" href="index.css" />
-  <link rel="stylesheet" href="index.css" />
   <link rel="stylesheet" href="./styles/clock.css">
   <link rel="stylesheet" href="./styles/cards.css">
   <link rel="stylesheet" href="./styles/navigation.css">
   <link rel="stylesheet" href="./styles/statistics.css">
+  <link rel="stylesheet" href="./styles/game-frame.css">
 
   <script src="index.js" defer></script>
   <!-- Vue App (using ES module) -->
@@ -41,20 +41,15 @@ Owned by Team 04
     <h1>Team 04</h1>
   </header>
 
- 
- 
   <main class="game-frame">
-    Implement your game inside this tag.
-    <div id="app">
-      </div>
-    <hr>
-    Learning: <div id="display-vocab">(This should be replaced by a word)</div>
+    <div id="app"></div>
   </main>
 
   <footer>
+    <hr>
+    Learning: <div id="display-vocab">(This should be replaced by a word)</div>
     <small>Created as part of the "Software Engineering and Project Management" course 2025</small>
   </footer>
-
 </body>
   
 </html>

--- a/team04/styles/cards.css
+++ b/team04/styles/cards.css
@@ -8,6 +8,6 @@
 
 .card {
     border-radius: 10px;
-    height: 5vh;
-    width: 15vw;
+    height: 40px;
+    width: 100px;
 }

--- a/team04/styles/clock.css
+++ b/team04/styles/clock.css
@@ -1,3 +1,3 @@
 .clock {
-    height: 100%;
+    height: 150px;
 }

--- a/team04/styles/game-frame.css
+++ b/team04/styles/game-frame.css
@@ -1,0 +1,13 @@
+.game-frame {
+    border: 2px solid black;
+}
+
+/* Cards + Clock */ 
+.center-section {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 5vw;
+}

--- a/team04/styles/navigation.css
+++ b/team04/styles/navigation.css
@@ -2,12 +2,11 @@
     align-items: center;
     display: flex;
     flex-direction: column;
-    width: 50vw;
     background-color: pink;
 }
 
 .navigation button {
-    height: 50px;
+    height: 40px;
     width: 100px;
 }
 

--- a/team04/styles/statistics.css
+++ b/team04/styles/statistics.css
@@ -2,9 +2,8 @@
     align-items: center;
     background-color: aquamarine;
     display: flex;
-    height: 10vh;
     justify-content: center;
-    width: 50vw;
+    width: 100%;
 }
 
 .level-indicator {


### PR DESCRIPTION
CSS styling of the page layout has been changed so that all elements should conform to the 800x600px restriction of the game-frame. The game-frame now has a black border so that it'll be easier to see the boundaries of where the game should be.

A discussion should be had on what to do with our own header (text: 'Clock it!') and footer (text '© 2025 Team 04') elements that are currently inside the game-frame. These are currently loaded as templates from inside the 'app.js' file, which means that they'll "live" inside of the game-frame, unlike the header and footer elements that we were given from the start which reside within the index.html file. NOTE: I've left these untouched for now.

_______________________________________________________________________________________
Additional changes:

* Added a game-frame.css file.

* Changed *title* tag from 'Basic static site' to 'Clock it' in index.html.

* Removed duplicate links to the 'index.css' stylesheet in index.html.

* Removed the 'Implement your game inside this tag' string that was inside of the game-frame element in index.html.

* Moved the *hr* and the *div* element with ID "display-vocab", which says "Learning: (This should be replaced by a word)" from the *game-frame* to the *footer*, since it interfered with the styling. 

* Button elements now use *px* sizing, instead of dynamic, to prevent game-frame overflow.


<img width="903" height="1292" alt="image" src="https://github.com/user-attachments/assets/0f10af85-bd97-4260-b243-596e52e3a630" />
